### PR TITLE
Use autocomplete fix

### DIFF
--- a/develnext/src/ide/autocomplete/php/PhpAnyAutoCompleteType.php
+++ b/develnext/src/ide/autocomplete/php/PhpAnyAutoCompleteType.php
@@ -73,7 +73,7 @@ class PhpAnyAutoCompleteType extends AutoCompleteType
                 if ($regex->find()) {
                     $pos = $regex->end(0) + 1;
                 } else {
-                    $regex = Regex::of('(\\<\\?)', Regex::DOTALL | Regex::CASE_INSENSITIVE)->with($text);
+                    $regex = Regex::of('(\\<\\?(php)?)', Regex::DOTALL | Regex::CASE_INSENSITIVE)->with($text);
 
                     if ($regex->find()) {
                         $pos = $regex->end(0) + 1;


### PR DESCRIPTION
Автодополнение use некорректно работает с тегом <?php
```php
<?p
use Exception;
hp

class test123
{
}
```
